### PR TITLE
Moved ranking to list comprehensions and using heapq

### DIFF
--- a/autoload/pymatcher.vim
+++ b/autoload/pymatcher.vim
@@ -17,6 +17,7 @@ function! pymatcher#PyMatch(items, str, limit, mmode, ispath, crfile, regex)
 
 exec (has('python') ? ':py' : ':py3') ' << EOF'
 import vim, re
+import heapq
 from datetime import datetime
 
 items = vim.eval('a:items')
@@ -85,10 +86,7 @@ if mmode == 'filename-only':
 else:
     res = [(path_score(line), line) for line in items]
 
-sortedlist = sorted(res, key=lambda x: x[0], reverse=True)[:limit]
-sortedlist = [x[1] for x in sortedlist]
-
-rez.extend(sortedlist)
+rez.extend([line for score, line in heapq.nlargest(limit, res)])
 
 vim.command("let s:regex = '%s'" % regex)
 EOF


### PR DESCRIPTION
There are two main changes in this PR. The first is to move the loops into list comprehensions through the use of two new functions: filename_score and path_score (a minor change to make that a little tidier was that line that do not match the pattern are given a score of zero). The second major change is to use the heapq library to find the best scores so that less sorting needs to be performed.
