### PR TITLE
Support the first-non-tab and until-last-tab match modes.

### DIFF
--- a/autoload/pymatcher.vim
+++ b/autoload/pymatcher.vim
@@ -83,6 +83,13 @@ def path_score(line):
 
 if mmode == 'filename-only':
     res = [(filename_score(line), line) for line in items]
+
+elif mmode == 'first-non-tab':
+    res = [(path_score(line.split('\t')[0]), line) for line in items]
+
+elif mmode == 'until-last-tab':
+    res = [(path_score(line.rsplit('\t')[0]), line) for line in items]
+
 else:
     res = [(path_score(line), line) for line in items]
 


### PR DESCRIPTION
Tag matching (CtrlPTag) requires first-non-tab support to work as
expected--matching against the tag only, instead of including the path.
The until-last-tab mechanism is used by CtrlPChange.

This also fixes #4.
