### PR TITLE
remove vim.bindeval dependency

### DIFF
--- a/autoload/pymatcher.vim
+++ b/autoload/pymatcher.vim
@@ -27,7 +27,7 @@ limit = int(vim.eval('a:limit'))
 mmode = vim.eval('a:mmode')
 aregex = int(vim.eval('a:regex'))
 
-rez = vim.bindeval('s:rez')
+rez = vim.eval('s:rez')
 
 specialChars = ['^','$','.','{','}','(',')','[',']','\\','/','+']
 
@@ -96,6 +96,7 @@ else:
 rez.extend([line for score, line in heapq.nlargest(limit, res)])
 
 vim.command("let s:regex = '%s'" % regex)
+vim.command("let s:rez = %s" % str(rez))
 EOF
 
     let s:matchregex = '\v\c'


### PR DESCRIPTION
Addresses #2 and neovim/neovim#1558

This is done to be compatible with neovim, which does not support bindeval. Also makes this plugin compatible with vim < 7.4.

I'm not sure about the impact that this has on performance: @FelikZ can you give me insight on how you did your profiling so I can check?
