### PR TITLE
Extract python code to autolaod/pymatcher.py

### DIFF
--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -1,0 +1,82 @@
+import vim, re
+import heapq
+from datetime import datetime
+
+def CtrlPPyMatch():
+    items = vim.eval('a:items')
+    astr = vim.eval('a:str')
+    lowAstr = astr.lower()
+    limit = int(vim.eval('a:limit'))
+    mmode = vim.eval('a:mmode')
+    aregex = int(vim.eval('a:regex'))
+
+    rez = vim.eval('s:rez')
+
+    specialChars = ['^','$','.','{','}','(',')','[',']','\\','/','+']
+
+    regex = ''
+    if aregex == 1:
+        regex = astr
+    else:
+        if len(lowAstr) == 1:
+            c = lowAstr
+            if c in specialChars:
+                c = '\\' + c
+            regex += c
+        else:
+            for c in lowAstr[:-1]:
+                if c in specialChars:
+                    c = '\\' + c
+                regex += c + '[^' + c + ']*'
+            else:
+                c = lowAstr[-1]
+                if c in specialChars:
+                    c = '\\' + c
+                regex += c
+
+    res = []
+    prog = re.compile(regex)
+
+    def filename_score(line):
+        # get filename via reverse find to improve performance
+        slashPos = line.rfind('/')
+        line = line if slashPos == -1 else line[slashPos + 1:]
+
+        lineLower = line.lower()
+        result = prog.search(lineLower)
+        if result:
+            score = result.end() - result.start() + 1
+            score = score + ( len(lineLower) + 1 ) / 100.0
+            score = score + ( len(line) + 1 ) / 1000.0
+            return 1000.0 / score
+
+        return 0
+
+
+    def path_score(line):
+        lineLower = line.lower()
+        result = prog.search(lineLower)
+        if result:
+            score = result.end() - result.start() + 1
+            score = score + ( len(lineLower) + 1 ) / 100.0
+            return 1000.0 / score
+
+        return 0
+
+
+    if mmode == 'filename-only':
+        res = [(filename_score(line), line) for line in items]
+
+    elif mmode == 'first-non-tab':
+        res = [(path_score(line.split('\t')[0]), line) for line in items]
+
+    elif mmode == 'until-last-tab':
+        res = [(path_score(line.rsplit('\t')[0]), line) for line in items]
+
+    else:
+        res = [(path_score(line), line) for line in items]
+
+    rez.extend([line for score, line in heapq.nlargest(limit, res)])
+
+    vim.command("let s:regex = '%s'" % regex)
+    vim.command("let s:rez = %s" % str(rez))

--- a/autoload/pymatcher.vim
+++ b/autoload/pymatcher.vim
@@ -4,6 +4,14 @@ if !has('python') && !has('python3')
     echo 'In order to use pymatcher plugin, you need +python or +python3 compiled vim'
 endif
 
+let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
+
+if has('python3')
+  execute 'py3file ' . s:plugin_path . '/pymatcher.py'
+else
+  execute 'pyfile ' . s:plugin_path . '/pymatcher.py'
+endif
+
 function! pymatcher#PyMatch(items, str, limit, mmode, ispath, crfile, regex)
 
     call clearmatches()
@@ -15,89 +23,7 @@ function! pymatcher#PyMatch(items, str, limit, mmode, ispath, crfile, regex)
     let s:rez = []
     let s:regex = ''
 
-exec (has('python') ? ':py' : ':py3') ' << EOF'
-import vim, re
-import heapq
-from datetime import datetime
-
-items = vim.eval('a:items')
-astr = vim.eval('a:str')
-lowAstr = astr.lower()
-limit = int(vim.eval('a:limit'))
-mmode = vim.eval('a:mmode')
-aregex = int(vim.eval('a:regex'))
-
-rez = vim.eval('s:rez')
-
-specialChars = ['^','$','.','{','}','(',')','[',']','\\','/','+']
-
-regex = ''
-if aregex == 1:
-    regex = astr
-else:
-    if len(lowAstr) == 1:
-        c = lowAstr
-        if c in specialChars:
-            c = '\\' + c
-        regex += c
-    else:
-        for c in lowAstr[:-1]:
-            if c in specialChars:
-                c = '\\' + c
-            regex += c + '[^' + c + ']*'
-        else:
-            c = lowAstr[-1]
-            if c in specialChars:
-                c = '\\' + c
-            regex += c
-
-res = []
-prog = re.compile(regex)
-
-def filename_score(line):
-    # get filename via reverse find to improve performance
-    slashPos = line.rfind('/')
-    line = line if slashPos == -1 else line[slashPos + 1:]
-
-    lineLower = line.lower()
-    result = prog.search(lineLower)
-    if result:
-        score = result.end() - result.start() + 1
-        score = score + ( len(lineLower) + 1 ) / 100.0
-        score = score + ( len(line) + 1 ) / 1000.0
-        return 1000.0 / score
-
-    return 0
-
-
-def path_score(line):
-    lineLower = line.lower()
-    result = prog.search(lineLower)
-    if result:
-        score = result.end() - result.start() + 1
-        score = score + ( len(lineLower) + 1 ) / 100.0
-        return 1000.0 / score
-
-    return 0
-
-
-if mmode == 'filename-only':
-    res = [(filename_score(line), line) for line in items]
-
-elif mmode == 'first-non-tab':
-    res = [(path_score(line.split('\t')[0]), line) for line in items]
-
-elif mmode == 'until-last-tab':
-    res = [(path_score(line.rsplit('\t')[0]), line) for line in items]
-
-else:
-    res = [(path_score(line), line) for line in items]
-
-rez.extend([line for score, line in heapq.nlargest(limit, res)])
-
-vim.command("let s:regex = '%s'" % regex)
-vim.command("let s:rez = %s" % str(rez))
-EOF
+    execute 'python' . (has('python3') ? '3' : '') . ' CtrlPPyMatch()'
 
     let s:matchregex = '\v\c'
 


### PR DESCRIPTION
I have extracted out the python code into `autolaod/pymatcher.py`. This means the python code is easier to maintain. As an added bonus the code is only loaded once instead on every call of `pymatcher#PyMatch`