### PR TITLE
Format lines correctly when matching tags

### DIFF
--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -78,5 +78,8 @@ def CtrlPPyMatch():
 
     rez.extend([line for score, line in heapq.nlargest(limit, res)])
 
+    # Use double quoted vim strings
+    vimrez = ['"%s"' % line.replace('"', '\\"') for line in rez]
+
     vim.command("let s:regex = '%s'" % regex)
-    vim.command("let s:rez = %s" % str(rez))
+    vim.command('let s:rez = [%s]' % ','.join(vimrez))


### PR DESCRIPTION
Remove use of literal strings when returning the match results to vim as
they broke CtrlPBufTag and CtrlPTag and showed \t instead of tabs in the
results.

Fixes #12