### PR TITLE
Escaping "\" for the paths returned to Vim, an issue on Win32

### DIFF
--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -78,12 +78,8 @@ def CtrlPPyMatch():
 
     rez.extend([line for score, line in heapq.nlargest(limit, res)])
 
-    # Protect output from '\' (mostly win32 path separators)
-    escrez = [line.replace('\\', '\\\\') for line in rez]
-
     # Use double quoted vim strings
-    vimrez = ['"%s"' % line.replace('"', '\\"') for line in escrez]
+    vimrez = ['"%s"' % line.replace('"', '\\"').replace('\\', '\\\\') for line in rez]
 
     vim.command("let s:regex = '%s'" % regex)
     vim.command('let s:rez = [%s]' % ','.join(vimrez))
-

--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -78,8 +78,9 @@ def CtrlPPyMatch():
 
     rez.extend([line for score, line in heapq.nlargest(limit, res)])
 
-    # Use double quoted vim strings
-    vimrez = ['"%s"' % line.replace('"', '\\"').replace('\\', '\\\\') for line in rez]
+    # Use double quoted vim strings and escape \
+    vimrez = ['"' + line.replace('"', '\\"').replace('\\', '\\\\') + '"' for line in rez]
 
     vim.command("let s:regex = '%s'" % regex)
     vim.command('let s:rez = [%s]' % ','.join(vimrez))
+    

--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -78,8 +78,12 @@ def CtrlPPyMatch():
 
     rez.extend([line for score, line in heapq.nlargest(limit, res)])
 
+    # Protect output from '\' (mostly win32 path separators)
+    escrez = [line.replace('\\', '\\\\') for line in rez]
+
     # Use double quoted vim strings
-    vimrez = ['"%s"' % line.replace('"', '\\"') for line in rez]
+    vimrez = ['"%s"' % line.replace('"', '\\"') for line in escrez]
 
     vim.command("let s:regex = '%s'" % regex)
     vim.command('let s:rez = [%s]' % ','.join(vimrez))
+


### PR DESCRIPTION
The output of the ctrlp matcher is scrambled on windows. All the path separator are interpreted by vim during the python->vim transfer, which cause problems. It should probably be the same on other systems, if anyone is crazy enough to put "\" in a filename.

This very simple fix add a step where all "\" are correctly escaped. Other problems remains, mostly on "filename-only", but the fix is less straightforward and I don't know enough vim to complete it cleanly.

Thank you for this plugin ! It greatly enhance the experience !