### PR TITLE
Fix file not in list

### DIFF
--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -12,7 +12,7 @@ def CtrlPPyMatch():
     aregex = int(vim.eval('a:regex'))
     crfile = vim.eval('a:crfile')
 
-    if int(vim.eval("pymatcher#ShouldHideCurrentFile(a:ispath, a:crfile)")):
+    if crfile in items and int(vim.eval("pymatcher#ShouldHideCurrentFile(a:ispath, a:crfile)")):
         items.remove(crfile)
 
     rez = vim.eval('s:rez')

--- a/autoload/pymatcher.py
+++ b/autoload/pymatcher.py
@@ -27,8 +27,7 @@ def CtrlPPyMatch():
         # If the string is longer that one character, append a mismatch
         # expression to each character (except the last).
         if len(lowAstr) > 1:
-            mismatch = ["[^" + c + "]*" for c in escaped[:-1]]
-            regex = ''.join([c for pair in zip(escaped[:-1], mismatch) for c in pair])
+            regex = ''.join([c + "[^" + c + "]*" for c in escaped[:-1]])
 
         # Append the last character in the string to the regex
         regex += escaped[-1]


### PR DESCRIPTION
When `let g:ctrlp_match_current_file=0` is enabled, if the current file is not present in the list, `items.remove(crfile)` trhows. So it's better to check its presence before removing it.

Also simplify the regex generation. I think it would be a good idea to add a `?` after `*` to make it non-greedy, but then its harder to set `s:regex`.