### PR TITLE
Load python3 before python2

### DIFF
--- a/autoload/pymatcher.vim
+++ b/autoload/pymatcher.vim
@@ -1,6 +1,6 @@
 " Python Matcher
 
-if !has('python') && !has('python3')
+if !has('python3') && !has('python') 
     echo 'In order to use pymatcher plugin, you need +python or +python3 compiled vim'
 endif
 

--- a/doc/pymatcher.txt
+++ b/doc/pymatcher.txt
@@ -36,8 +36,8 @@ INSTALL                         *pymatcher-install*
     To enable |pymatcher| insert the following in your .vimrc:
 >
     " PyMatcher for CtrlP
-    if !has('python')
-        echo 'In order to use pymatcher plugin, you need +python compiled vim'
+    if !has('python3') && !has('python') 
+        echo 'In order to use pymatcher plugin, you need +python or +python3 compiled vim'
     else
         let g:ctrlp_match_func = { 'match': 'pymatcher#PyMatch' }
     endif


### PR DESCRIPTION
The old way causes issues with plugins that only support python3

Just calling `has('python')` will make vim load python2 (if it hasn't
already loaded a python version).

So if the first thing you do when opening vim is call CtrlP, vim loads
python2 and any plugin that only uses python3 won't work any longer.

Since this plugin supports python3 and we should use it whenever
possible the best way is to first check if python3 is available so that
vim loads python3